### PR TITLE
[new release] ocamlformat, ocamlformat-rpc and ocamlformat-rpc-lib (unreleased)

### DIFF
--- a/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.unreleased/opam
+++ b/packages/ocamlformat-rpc-lib/ocamlformat-rpc-lib.unreleased/opam
@@ -1,0 +1,40 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "csexp"
+  "sexplib0"
+  "odoc" {with-doc}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "bb693c708b0e79e1e827c9dbbb270e706e3f4ca4"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/test/ocamlformat-rpc-lib-unreleased.tbz"
+  checksum: [
+    "sha256=9c98d68f6aee49306780a3dc13300cadb746d7a203166f56647442dda8c4818b"
+    "sha512=fc6b1e44bc0f9467bb7c63da34edec337e00776e470c63fc6febaabaf59fda678091604b9cea543a0c2d14f18e67f19dd4f8203bc968a4e314ab3601bb5420d7"
+  ]
+}

--- a/packages/ocamlformat-rpc/ocamlformat-rpc.unreleased/opam
+++ b/packages/ocamlformat-rpc/ocamlformat-rpc.unreleased/opam
@@ -1,0 +1,58 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code (RPC mode)"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style. This package defines a RPC interface to OCamlFormat"
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "ocaml-version"
+  "ocamlformat-rpc-lib"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.22.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "bb693c708b0e79e1e827c9dbbb270e706e3f4ca4"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/test/ocamlformat-rpc-lib-unreleased.tbz"
+  checksum: [
+    "sha256=9c98d68f6aee49306780a3dc13300cadb746d7a203166f56647442dda8c4818b"
+    "sha512=fc6b1e44bc0f9467bb7c63da34edec337e00776e470c63fc6febaabaf59fda678091604b9cea543a0c2d14f18e67f19dd4f8203bc968a4e314ab3601bb5420d7"
+  ]
+}

--- a/packages/ocamlformat/ocamlformat.unreleased/opam
+++ b/packages/ocamlformat/ocamlformat.unreleased/opam
@@ -1,0 +1,57 @@
+opam-version: "2.0"
+synopsis: "Auto-formatter for OCaml code"
+description:
+  "OCamlFormat is a tool to automatically format OCaml code in a uniform style."
+maintainer: ["OCamlFormat Team <ocamlformat-dev@lists.ocaml.org>"]
+authors: ["Josh Berdine <jjb@fb.com>"]
+license: "MIT"
+homepage: "https://github.com/ocaml-ppx/ocamlformat"
+bug-reports: "https://github.com/ocaml-ppx/ocamlformat/issues"
+depends: [
+  "dune" {>= "2.8"}
+  "ocaml" {>= "4.08" & < "4.13"}
+  "ocaml-version"
+  "alcotest" {with-test}
+  "base" {>= "v0.12.0" & < "v0.15"}
+  "base-unix"
+  "cmdliner"
+  "dune-build-info"
+  "either"
+  "fix"
+  "fpath"
+  "menhir" {>= "20180528"}
+  "menhirLib" {>= "20200624"}
+  "menhirSdk" {>= "20200624"}
+  "ocp-indent" {with-test}
+  "bisect_ppx" {with-test & >= "2.5.0"}
+  "odoc" {>= "1.4.2"}
+  "ppxlib" {>= "0.22.0"}
+  "re"
+  "stdio" {< "v0.15"}
+  "uuseg" {>= "10.0.0"}
+  "uutf" {>= "1.0.1"}
+]
+build: [
+  ["dune" "subst"] {dev}
+  [
+    "dune"
+    "build"
+    "-p"
+    name
+    "-j"
+    jobs
+    "@install"
+    "@runtest" {with-test}
+    "@doc" {with-doc}
+  ]
+]
+dev-repo: "git+https://github.com/ocaml-ppx/ocamlformat.git"
+x-commit-hash: "bb693c708b0e79e1e827c9dbbb270e706e3f4ca4"
+url {
+  src:
+    "https://github.com/ocaml-ppx/ocamlformat/releases/download/test/ocamlformat-rpc-lib-unreleased.tbz"
+  checksum: [
+    "sha256=9c98d68f6aee49306780a3dc13300cadb746d7a203166f56647442dda8c4818b"
+    "sha512=fc6b1e44bc0f9467bb7c63da34edec337e00776e470c63fc6febaabaf59fda678091604b9cea543a0c2d14f18e67f19dd4f8203bc968a4e314ab3601bb5420d7"
+  ]
+}


### PR DESCRIPTION
Auto-formatter for OCaml code

- Project page: <a href="https://github.com/ocaml-ppx/ocamlformat">https://github.com/ocaml-ppx/ocamlformat</a>

##### CHANGES:

#### Removed

#### Deprecated

#### Bug fixes

  + Fix formatting of odoc tags: the argument should be on the same line, indent description that wraps (ocaml-ppx/ocamlformat#1634, ocaml-ppx/ocamlformat#1635, @gpetiot)

  + Consistently format let bindings and monadic let bindings, do not drop comments before monadic bindings (ocaml-ppx/ocamlformat#1636, @gpetiot)

#### Changes

#### New features
